### PR TITLE
Fix SA permissions

### DIFF
--- a/ansible/roles/ocp4_workload_stackrox_demo_apps/files/demos/backend/everything.yaml
+++ b/ansible/roles/ocp4_workload_stackrox_demo_apps/files/demos/backend/everything.yaml
@@ -97,6 +97,10 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["*"]
+  - apiGroups: ["security.openshift.io"]
+    resourceNames: ["anyuid"]
+    resources: ["securitycontextconstraints"]
+    verbs: ["use"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/ansible/roles/ocp4_workload_stackrox_demo_apps/files/demos/frontend/everything.yaml
+++ b/ansible/roles/ocp4_workload_stackrox_demo_apps/files/demos/frontend/everything.yaml
@@ -16,7 +16,46 @@ metadata:
 data:
   id_rsa: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlDWGdJQkFBS0JnUURSVk4vbFYxOFFYMnBmQlNLYVowVVlDVlk2TDFSRDlhNy9QRGtmVlpJRXdTUCszczIzCmpHU3NZanhxZXliT0lEZzI3dndkWkw5R1dEd2Nsb2lVbmhjWUpDSlJaalN4VUw5MmJJSGVhYitYSnJQUGRFNmUKbnZLTmpsSE1nampxdVhQWGkrQmpjNDgvd1BGYnhLVndSclYwOUFZOUpDbXBWZUhqdUFHUStwbmk2d0lEQVFBQgpBb0dCQUpkWWpSUk1xaisxTEx3TWcyc3RGUWgrMzZmcnhqbm9iS0MrMHZIenRVSFl2b1NzWkFHNzhLR3QyTTZICndaT3dPZFNGenlRVlRqRzI0NmNyc3czNGl1cXJtd2Q1Qmhhb0hEbmhGN3pqZkMybUN5MjlkNGF4cGY0N1NZMGYKais5bHEzSzNrRDhkcVBQTzhGRnhjQlNmSGw3ejFWR2ppbmx1V1UwbHBUN1V4YlY1QWtFQTZkMElkYTJFMlo1LwpjYTZIQXdQVGpIOUFMYzhwQlI0bXg4Q2pUN1BWZk1ncUV5SGdTRGx3aGw4V3Z2OHFWVG0xRDdxUFhoS21FeTVhCnZWdDlnUE9PclFKQkFPVWxZdS85ZUNWODY0L2VacWhWYXlBT0JIUHNUQ3ZpZ04wNk83MDBHeldPVlVGR0pxUkoKY2dWRnNhVjBudytrU3FxaFdTRVJGS1JxM3RHYmFlK1JZdmNDUUUwSjRDQ0w0YWlpbXM4RE5EeWRCUkpTVlAwQwpNandhVzZJUDVueDUvRWpYMDJ4c0Myc2ZhTjhLOGY1SEpsWGU1Yk5odkpxN3YvT3ZvSHFpYWV5Unp4MENRUUM2CkM2TEtxNGRUR0p2QlVaY1Q4VlpxemphN1VBMkFUQVRJbWJGTEt2VTBoSDJmNDY4WUVER3RLaXJUNVY0SHV5S00KYXpnTWF1dlJtcHVTbjVaaFZpOTlBa0VBaWtIanNZZW5YVWNaSHpHZzVTZ3RGc29DdXV2eEdNenpNc2cyVWZIVgo5TnNXNXoxcytHNmM2bXhCMmxFaTRVcEswc0xJeTMyZG9NRVpKQkp2cGN5MVZ3PT0KLS0tLS1FTkQgUlNBIFBSSVZBVEUgS0VZLS0tLS0K
   id_rsa.pub: c3NoLXJzYSBBQUFBQjNOemFDMXljMkVBQUFBREFRQUJBQUFBZ1FEUlZOL2xWMThRWDJwZkJTS2FaMFVZQ1ZZNkwxUkQ5YTcvUERrZlZaSUV3U1ArM3MyM2pHU3NZanhxZXliT0lEZzI3dndkWkw5R1dEd2Nsb2lVbmhjWUpDSlJaalN4VUw5MmJJSGVhYitYSnJQUGRFNmVudktOamxITWdqanF1WFBYaStCamM0OC93UEZieEtWd1JyVjA5QVk5SkNtcFZlSGp1QUdRK3BuaTZ3PT0gaGFja2VybWFuCg==
-
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: frontend-sa
+  namespace: frontend
+  labels:
+    app: frontend
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: frontend-role
+  namespace: frontend
+  labels:
+    app: frontend
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["*"]
+  - apiGroups: ["security.openshift.io"]
+    resourceNames: ["anyuid"]
+    resources: ["securitycontextconstraints"]
+    verbs: ["use"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: frontend-binding
+  namespace: frontend
+  labels:
+    app: frontend
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: frontend-role
+subjects:
+  - kind: ServiceAccount
+    name: frontend-sa
+    namespace: frontend
 ---
 # Deployment named "asset-cache"
 # Listens on :8080
@@ -38,6 +77,7 @@ spec:
       labels:
         app: asset-cache
     spec:
+      serviceAccountName: frontend-sa
       imagePullSecrets:
         - name: gcrcred
       containers:
@@ -167,6 +207,7 @@ spec:
       labels:
         app: wordpress
     spec:
+      serviceAccountName: frontend-sa
       containers:
         - image: wordpress:latest
           imagePullPolicy: Always

--- a/ansible/roles/ocp4_workload_stackrox_demo_apps/files/demos/payments/everything.yaml
+++ b/ansible/roles/ocp4_workload_stackrox_demo_apps/files/demos/payments/everything.yaml
@@ -195,7 +195,22 @@ metadata:
   namespace: payments
   labels:
     app: mastercard-processor
-
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: mastercard-role
+  namespace: payments
+  labels:
+    app: mastercard-processor
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["*"]
+  - apiGroups: ["security.openshift.io"]
+    resourceNames: ["anyuid"]
+    resources: ["securitycontextconstraints"]
+    verbs: ["use"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -207,7 +222,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: cluster-admin
+  name: mastercard-role
 subjects:
   - kind: ServiceAccount
     name: mastercard-processor


### PR DESCRIPTION
Remove cluster-admin for all SAs, add access to anyuid SCC for those that need it.

This resolves a conflict with the compliance operator and a race condition with the pods that now have anyuid.